### PR TITLE
Fix for searching the correct theme name

### DIFF
--- a/automations/frontend.yaml
+++ b/automations/frontend.yaml
@@ -44,8 +44,9 @@
     service: frontend.set_theme
     data:
       name: >
+        {% set mode_name = "dark-mode" if is_state("input_boolean.dark_mode", "on") else "light-mode" -%}
         {% set name = states("input_select.theme") -%}
         {% set suffix = "-alternative" if is_state("input_boolean.theme_alternative", "on") else "" -%}
-        ios-{{ name }}{{ suffix }}
+        ios-{{ mode_name }}-{{ name }}{{ suffix }}
       mode: >
         {{ "dark" if is_state("input_boolean.dark_mode", "on") else "light" }}


### PR DESCRIPTION
The 'input_select.theme' selector was looking for theme names with the incorrect name. 

It was (for example) searching for theme 'ios-dark-green' where the theme names 'ios-light-mode-dark-green' and 'ios-dark-mode-dark-green' only exists.

I'm not sure this is the correct location for a fix, but this works for me. Feel free to decline the PR if this is incorrect or ask me any questions. I'm happy to help 
